### PR TITLE
feat: 增加用户信息，默认从git配置，可修改相关方法改成从相关鉴权系统获取

### DIFF
--- a/lib/core/initClient.js
+++ b/lib/core/initClient.js
@@ -69,13 +69,13 @@ class Client {
           return self.initUserInfo().then((userInfo)=>{
               npmConfig['userName'] = userInfo.userName;
               npmConfig['userEmail'] = userInfo.userEmail;
-              log.debug('获取 git config 成功');
+              log.debug('获取 user config 成功');
               self.setFeflowYml(npmConfig);
               process.exit(2);
               resolve(ctx);
             }, (e)=>{
               self.setFeflowYml(npmConfig);
-              log.debug('获取 git config 失败');
+              log.debug('获取 user config 失败');
               process.exit(2);
               reject(ctx);
             });
@@ -95,13 +95,13 @@ class Client {
         }).then((userInfo)=>{
               self.answer['userName'] = userInfo.userName;
               self.answer['userEmail'] = userInfo.userEmail;
-              log.debug('获取 git config 成功');
+              log.debug('获取 user config 成功');
               self.setFeflowYml(self.answer);
               process.exit(2);
               resolve(ctx);
             }, (e)=>{
               self.setFeflowYml(self.answer);
-              log.debug('获取 git config 失败');
+              log.debug('获取 user config 失败');
               process.exit(2);
               reject(ctx);
             });

--- a/lib/core/initClient.js
+++ b/lib/core/initClient.js
@@ -4,6 +4,7 @@ const fs = require('hexo-fs');
 const inquirer = require('inquirer');
 const Promise = require('bluebird');
 const utils = require('../utils');
+const spawn = require('cross-spawn');
 
 /**
  * Init feflow client, including ~/.feflow, ~/.feflow/package.json, ~/.feflow/.feflowrc.yml
@@ -54,7 +55,8 @@ class Client {
   }
 
   initLocalRc() {
-    const ctx = this.ctx;
+    const self = this;
+    const ctx  = this.ctx;
     const {rcPath, config, log} = ctx;
 
     return new Promise(function (resolve) {
@@ -73,13 +75,17 @@ class Client {
           for (let prop in answer) {
             answer[prop] = answer[prop].trim();
           }
-          // Save user config to local file system
-          utils.safeDump(answer, rcPath);
-          log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
-
-          log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
-          process.exit(2);
-          resolve(ctx);
+          // Save userInfo from git or anyotherSystem
+          self.initUserInfo().then((userInfo)=>{
+            answer['userName'] = userInfo.userName;
+            answer['userEmail'] = userInfo.userEmail;
+            // Save user config to local file system
+            utils.safeDump(answer, rcPath);
+            log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
+            log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
+            process.exit(2);
+            resolve(ctx);
+          });
         });
       } else {
         log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
@@ -99,6 +105,48 @@ class Client {
       resolve(ctx);
     });
   }
+
+  initUserInfo() {
+    // 从git获取 | anyotherSystem
+    let args = ['config', '-l'];
+    return new Promise((resolve)=>{
+      const getInfo = spawn('git', args);
+
+      let output = '';
+      getInfo.stdout.on('data', (data) => {
+        output += data;
+      });
+
+      getInfo.stderr.on('data', (data) => {
+        output += data;
+      }).pipe(process.stderr);
+
+      getInfo.on('close', (code) => {
+        if (!code) {
+          
+          let arr = output.split('\n'), 
+              result= {}, 
+              userName = "", 
+              userEmail = "";
+
+          arr.forEach((item)=>{
+            let keyValue = item.split('=');
+            result[keyValue[0]] = keyValue[1];
+          });
+         
+          if(result['user.email']){
+            userName = result['user.email'].split('@')[0];
+            userEmail = result['user.email'];
+          }
+          resolve({'userName':userName,'userEmail':userEmail});
+        } else {
+          reject({code: code, data: output});
+        }
+      });
+     
+    })
+  }
+
 }
 
 


### PR DESCRIPTION
最底层的cli一般需处理及管理用户信息，刚使用feflow的时候有些团队或者部门还没有很完善的登录鉴权系统， 这时候如果有一个默认的user配置及相关方法的收口，可以方便用做数据统计，日志鉴权等。git信息不准确或者不满足需求可以等基建之后替换相关方法就可以完成自己的用户系统。