### PR TITLE
feat: 常用及通用的功能传递给 脚手架|builder|deploy 及插件使用

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -11,6 +11,7 @@ const { camelizeKeys } = require('humps');
 const logger = require('./logger');
 const Command = require('./command');
 const utils = require('../utils');
+const Loading = require('../utils');
 const pkg = require('../../package.json');
 const sep = pathFn.sep;
 
@@ -47,6 +48,19 @@ class Feflow {
     this.args = camelizeKeys(args);
 
     this.cmd = new Command();
+    
+    // 常用及通用的功能传递给 脚手架|builder|deploy 及插件使用
+    this.coreFn = {
+      // 一系列常用库集合 如chalk inquirer opn 等等
+      chalk: chalk,
+      // 执行异步操作可调用统一输出产品 feflow 心智
+      Loading: Loading,
+      // 实用方法套件插件也使用
+      log: this.log
+      // 数据埋点方法函数..
+      // 消息通知 notice 等封装函数..
+    };
+
   }
 
   /**

--- a/lib/internal/build/builder.js
+++ b/lib/internal/build/builder.js
@@ -16,6 +16,7 @@ class Builder {
   }
 
   runBuild(cmd) {
+    const self = this;
     const { log, pluginDir, baseDir } = this.ctx;
     const type = Config.getBuilderType();
     const path = pathFn.join(pluginDir, type);
@@ -27,7 +28,7 @@ class Builder {
         if (!result.code) {
           loading.success();
           log.info(`${type} 构建器安装完成, 即将执行构建命令...`);
-          require(path)(cmd);
+          require(path)(cmd, self.ctx);
         } else {
           const err = `${type} 构建器安装失败，失败码为${result.code}，错误日志为${result.data}`;
           loading.fail(err);
@@ -36,7 +37,7 @@ class Builder {
       });
     } else {
       return this.checkUpdate().then(() => {
-        require(path)(cmd);
+        require(path)(cmd, self.ctx);
       });
     }
   }

--- a/lib/internal/deploy/deployer.js
+++ b/lib/internal/deploy/deployer.js
@@ -16,6 +16,7 @@ class Deployer {
   }
 
   runBuild(cmd) {
+    const self = this;
     const { log, pluginDir, baseDir } = this.ctx;
     const type = Config.getDeployerType();
     const path = pathFn.join(pluginDir, type);
@@ -27,7 +28,7 @@ class Deployer {
         if (!result.code) {
           loading.success();
           log.info(`${type} 部署器安装完成, 即将执行构建命令...`);
-          require(path)(cmd);
+          require(path)(cmd, self.ctx);
         } else {
           const err = `${type} 部署器安装失败，失败码为${result.code}，错误日志为${result.data}`;
           loading.fail(err);
@@ -36,7 +37,7 @@ class Deployer {
       });
     } else {
       return this.checkUpdate().then(() => {
-        require(path)(cmd);
+        require(path)(cmd, self.ctx);
       });
     }
   }

--- a/lib/internal/generator/generator.js
+++ b/lib/internal/generator/generator.js
@@ -210,7 +210,7 @@ class Generator {
     }
 
     yeomanEnv.register(require.resolve(path), name);
-    yeomanEnv.run(name, this.args, err => {
+    yeomanEnv.run(name, ctx, err => {
     });
   }
 


### PR DESCRIPTION
feflow让业务同学开发工作流程更简单，如果让贡献脚手架和插件的同学更简单，更高效就更好了!
小问题：
一、在写脚手架和插件的时候经常有一些通用方法如 chalk inquirer opn 需要套件单独安装，内置的优秀方法如：loading， log（错误日志，提示文案统一feflow心智）等也没办法使用。
二、脚手架|插件同学写的通用功能(例如数据埋点，检查用户信息等)希望可以收敛到feflow，封装一层coreFn，减少重复建设成本。除此之外feflow官方同学也可以往里面写很多优秀的方法传递下去。
方案：
如代码，在使用时候传一个coreFn到脚手架和插件里面， 减少开发者成本， 开发者贡献功能， 形成良性循环
小问题：
generator 那里 yeomanEnv.run(name, args, err => {
});
变成了
yeomanEnv.run(name, ctx, err => {
});

这里可能需要generator的同学修改一下 获取方式从 xxx.args[1].args --> xxx.args[1].ctx.args (大概)。
因为只涉及项目初始化， 只需要generator同学写一个小兼容，发布就可以了！