### PR TITLE
fix: 支持命令行直接完成feflow初始化 && 修复无法禁用检测插件更新

### DIFF
--- a/lib/core/initClient.js
+++ b/lib/core/initClient.js
@@ -4,7 +4,7 @@ const fs = require('hexo-fs');
 const inquirer = require('inquirer');
 const Promise = require('bluebird');
 const utils = require('../utils');
-
+const DEFAULTNPMREGEISTRY = 'http://registry.npmjs.org';
 /**
  * Init feflow client, including ~/.feflow, ~/.feflow/package.json, ~/.feflow/.feflowrc.yml
  */
@@ -54,33 +54,37 @@ class Client {
   }
 
   initLocalRc() {
+    const self = this;
+
     const ctx = this.ctx;
     const {rcPath, config, log} = ctx;
 
+    const npmConfig = this.getNpmConfig();
+    const {proxy, registry} = npmConfig;
+
     return new Promise(function (resolve) {
       if (!fs.existsSync(rcPath) || !config || !config.registry) {
-        inquirer.prompt([{
+        // 第一次初始化 且 命令行携带 --registry 信息就可以通过命令行直接完成初始化 并不阻塞 后续流程
+        if(registry) {
+          self.setFeflowYml(npmConfig);
+          resolve(ctx);
+        } else {
+         inquirer.prompt([{
           type: 'input',
           name: 'registry',
           message: '请输入npm的registry:',
-          default: 'http://registry.npmjs.org'
+          default: DEFAULTNPMREGEISTRY
         }, {
           type: 'input',
           name: 'proxy',
           message: '请输入npm的proxy(默认为空):'
         }]).then((answer) => {
-          // Handle user input, trim space
-          for (let prop in answer) {
-            answer[prop] = answer[prop].trim();
-          }
-          // Save user config to local file system
-          utils.safeDump(answer, rcPath);
-          log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
-
-          log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
-          process.exit(2);
-          resolve(ctx);
+            self.setFeflowYml(answer);
+            process.exit(2);
+            resolve(ctx);
         });
+        }
+       
       } else {
         log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
         resolve(ctx);
@@ -99,6 +103,35 @@ class Client {
       resolve(ctx);
     });
   }
+
+  getNpmConfig() {
+    const {args} = this.ctx;
+    if(args.registry || args.proxy || args.init) {
+      return {
+        registry: args.init ? DEFAULTNPMREGEISTRY : (args.registry || ''),
+        proxy: args.proxy || ''
+      };
+    };
+    // 默认值
+    return {};
+  }
+
+  setFeflowYml(npmConfig){
+    const {rcPath, config, log} = this.ctx;
+    // Handle user input, trim space
+    for (let prop in npmConfig) {
+      npmConfig[prop] = npmConfig[prop].trim();
+    }
+    // Modify oldConfig 
+    this.ctx.config = npmConfig;
+    // Save user config to local file system
+    utils.safeDump(npmConfig, rcPath);
+
+    log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
+
+    log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
+  }
+
 }
 
 

--- a/lib/core/upgrade.js
+++ b/lib/core/upgrade.js
@@ -19,13 +19,13 @@ class Upgrade {
     const self = this;
     const { config, log, args } = this.ctx;
     const registry = config && config.registry;
-
     log.debug('正在检查cli core更新...');
 
     if (args.disableCheck) {
       log.debug('用户禁用了cli core的更新检查');
       return;
     }
+   
 
     return pkgJson('feflow-cli', 'latest', registry).then(json => {
       const version = pkg.version;
@@ -58,10 +58,16 @@ class Upgrade {
 
   checkPlugin() {
     const self = this;
-    const { config, log, baseDir } = this.ctx;
+    const { config, log, baseDir, args} = this.ctx;
     const registry = config && config.registry;
 
     log.debug('正在检查cli plugin更新...');
+
+    if (args.disableCheck) {
+      log.debug('用户禁用了cli plugin的更新检查');
+      return;
+    };
+
 
     const table = new Table();
     return this.getInstalledPlugins().map((plugin) => {

--- a/test/scripts/core/feflow-container/.feflowrc.yml
+++ b/test/scripts/core/feflow-container/.feflowrc.yml
@@ -1,0 +1,2 @@
+proxy: ''
+registry: 'http://registry.npmjs.org'

--- a/test/scripts/core/feflow-container/rcPath
+++ b/test/scripts/core/feflow-container/rcPath
@@ -1,0 +1,4 @@
+proxy: ''
+registry: 'http://registry.npmjs.org'
+userEmail: xurui07@meituan.com
+userName: xurui07

--- a/test/scripts/core/initClient.js
+++ b/test/scripts/core/initClient.js
@@ -62,4 +62,33 @@ describe('initClient', () => {
     feflow.rcPath = path.resolve(__dirname, './feflow-container/.feflowrc.yml');
     initClient(feflow);
   })
+
+  it('initClient with --init args', () => {
+    feflow.args = {
+      '': [],
+      'init': true
+    };
+    initClient(feflow);
+  })
+
+
+  it('initClient with --registry args', () => {
+    feflow.args = {
+      '': [],
+      'registry': 'http://registry.npmjs.org'
+    };
+    initClient(feflow);
+  })
+
+  it('initClient with --proxy args', () => {
+    feflow.args = {
+      '': [],
+      'proxy': 'http://registry.npmjs.org'
+    };
+    initClient(feflow);
+  })
+
+
+
+
 })

--- a/test/scripts/core/initClient.js
+++ b/test/scripts/core/initClient.js
@@ -33,6 +33,9 @@ const feflow = {
     debug: Boolean(true),
     silent: Boolean(false)
   }),
+  args: {
+    '': []
+  },
   config: {
     registry: 'http://registry.npmjs.org'
   }

--- a/test/scripts/core/initClient.js
+++ b/test/scripts/core/initClient.js
@@ -88,6 +88,16 @@ describe('initClient', () => {
     initClient(feflow);
   })
 
+  it('initClient with --init args without config', () => {
+    feflow.args = {
+      '': [],
+      'init': true
+    };
+    feflow.config = '';
+    initClient(feflow);
+  })
+
+
 
 
 


### PR DESCRIPTION
支持命令行直接完成feflow初始化 && 修复无法禁用检测插件更新。
相关方法如下：
![image](https://user-images.githubusercontent.com/46240984/50585458-02789280-0eb0-11e9-9ad8-5bb08a34ac54.png)
