### PR TITLE
fix: support_command-init

### DIFF
--- a/lib/core/initClient.js
+++ b/lib/core/initClient.js
@@ -4,7 +4,7 @@ const fs = require('hexo-fs');
 const inquirer = require('inquirer');
 const Promise = require('bluebird');
 const utils = require('../utils');
-
+const DEFAULTNPMREGEISTRY = 'http://registry.npmjs.org';
 /**
  * Init feflow client, including ~/.feflow, ~/.feflow/package.json, ~/.feflow/.feflowrc.yml
  */
@@ -54,33 +54,37 @@ class Client {
   }
 
   initLocalRc() {
+    const self = this;
+
     const ctx = this.ctx;
     const {rcPath, config, log} = ctx;
 
+    const npmConfig = this.getNpmConfig();
+    const {proxy, registry} = npmConfig;
+
     return new Promise(function (resolve) {
       if (!fs.existsSync(rcPath) || !config || !config.registry) {
-        inquirer.prompt([{
+        // first init && command args with --registry 
+        if(registry) {
+          self.setFeflowYml(npmConfig);
+          resolve(ctx);
+        } else {
+         inquirer.prompt([{
           type: 'input',
           name: 'registry',
           message: '请输入npm的registry:',
-          default: 'http://registry.npmjs.org'
+          default: DEFAULTNPMREGEISTRY
         }, {
           type: 'input',
           name: 'proxy',
           message: '请输入npm的proxy(默认为空):'
         }]).then((answer) => {
-          // Handle user input, trim space
-          for (let prop in answer) {
-            answer[prop] = answer[prop].trim();
-          }
-          // Save user config to local file system
-          utils.safeDump(answer, rcPath);
-          log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
-
-          log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
-          process.exit(2);
-          resolve(ctx);
+            self.setFeflowYml(answer);
+            process.exit(2);
+            resolve(ctx);
         });
+        }
+       
       } else {
         log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
         resolve(ctx);
@@ -99,6 +103,35 @@ class Client {
       resolve(ctx);
     });
   }
+
+  getNpmConfig() {
+    const {args} = this.ctx;
+    if(args.registry || args.proxy || args.init) {
+      return {
+        registry: args.init ? DEFAULTNPMREGEISTRY : (args.registry || ''),
+        proxy: args.proxy || ''
+      };
+    };
+    return {};
+  }
+
+  setFeflowYml(npmConfig){
+    const {rcPath, config, log} = this.ctx;
+    // Handle user input, trim space
+    for (let prop in npmConfig) {
+      npmConfig[prop] = npmConfig[prop].trim();
+    }
+    // Modify oldConfig 
+    this.ctx.config = npmConfig;
+
+    // Save user config to local file system
+    utils.safeDump(npmConfig, rcPath);
+
+    log.debug('.feflow/.feflowrc.yml 配置文件已经创建');
+
+    log.info('初始化完成，请输入命令开启feflow的使用之旅。(帮助：feflow -h)');
+  }
+
 }
 
 

--- a/lib/core/upgrade.js
+++ b/lib/core/upgrade.js
@@ -58,10 +58,15 @@ class Upgrade {
 
   checkPlugin() {
     const self = this;
-    const { config, log, baseDir } = this.ctx;
+    const { config, log, baseDir, args } = this.ctx;
     const registry = config && config.registry;
 
     log.debug('正在检查cli plugin更新...');
+
+    if (args.disableCheck) {
+      log.debug('用户禁用了cli plugin的更新检查');
+      return;
+    };
 
     const table = new Table();
     return this.getInstalledPlugins().map((plugin) => {

--- a/test/scripts/core/initClient.js
+++ b/test/scripts/core/initClient.js
@@ -33,6 +33,9 @@ const feflow = {
     debug: Boolean(true),
     silent: Boolean(false)
   }),
+  args: {
+    '': []
+  },
   config: {
     registry: 'http://registry.npmjs.org'
   }
@@ -59,4 +62,40 @@ describe('initClient', () => {
     feflow.rcPath = path.resolve(__dirname, './feflow-container/.feflowrc.yml');
     initClient(feflow);
   })
+
+  it('initClient with --init args', () => {
+    feflow.args = {
+      '': [],
+      'init': true
+    };
+    initClient(feflow);
+  })
+
+
+  it('initClient with --registry args', () => {
+    feflow.args = {
+      '': [],
+      'registry': 'http://registry.npmjs.org'
+    };
+    initClient(feflow);
+  })
+
+  it('initClient with --proxy args', () => {
+    feflow.args = {
+      '': [],
+      'proxy': 'http://registry.npmjs.org'
+    };
+    initClient(feflow);
+  })
+
+  it('initClient with --init args without config', () => {
+    feflow.args = {
+      '': [],
+      'init': true
+    };
+    feflow.config = '';
+    initClient(feflow);
+  })
+
+
 })


### PR DESCRIPTION
支持命令行直接完成feflow初始化 && 修复无法禁用检测插件更新。
![image](https://user-images.githubusercontent.com/46240984/50629394-513d2f80-0f77-11e9-82bb-5e4937ad7277.png)
